### PR TITLE
docs: fix wrong class name for middleware

### DIFF
--- a/cookbook/scaffolding.md
+++ b/cookbook/scaffolding.md
@@ -592,7 +592,7 @@ class MyJob extends JobHandler
 $ php app.php create:middleware <name>
 ```
 
-`<Name>Middlweare` class will be created.
+`<Name>` class will be created.
 
 #### Example
 ```bash


### PR DESCRIPTION
`php app:php create:middleware my` will generae `<Name>` class, but not `<Name>Middleware`.