### PR TITLE
Fix typos for DEBUG env description

### DIFF
--- a/start/configuration.md
+++ b/start/configuration.md
@@ -8,7 +8,7 @@ by editing the file(s) in `app/config/`.
 Web and GRPC templates use DotEnv extension to read environment values from `.env` file located in the root of your project.
 
 ```env
-# Debug mode disabled view cache and enabled higher verbosity.
+# Debug mode set to TRUE disables view caching and enables higher verbosity.
 DEBUG = true
 
 # Set to application-specific value, used to encrypt/decrypt cookies, etc.

--- a/views/configuration.md
+++ b/views/configuration.md
@@ -84,7 +84,7 @@ class AppBootloader extends Bootloader
 ```
 
 ## Caching
-By default, the view caching turned off if env variable `DEBUG` set to true. The cache files are stored in 
+By default, view caching is turned off if the env variable `DEBUG` is set to true. The cache files are stored in 
 `runtime/cache/views`.
 
 ## Purge


### PR DESCRIPTION
Fixed some grammar issues in the description of what the DEBUG environment variable does.