### PR TITLE
Removed spaces from .env example

### DIFF
--- a/start/configuration.md
+++ b/start/configuration.md
@@ -9,13 +9,13 @@ Web and GRPC templates use DotEnv extension to read environment values from `.en
 
 ```env
 # Debug mode set to TRUE disables view caching and enables higher verbosity.
-DEBUG = true
+DEBUG=true
 
 # Set to application-specific value, used to encrypt/decrypt cookies, etc.
-ENCRYPTER_KEY = {encrypt-key}
+ENCRYPTER_KEY={encrypt-key}
 
 # Set to TRUE to disable confirmation in `migrate` commands.
-SAFE_MIGRATIONS = true
+SAFE_MIGRATIONS=true
 ```
 
 You can access these values using `Spiral\Boot\EnvironmentInterface` or via a short function `env`.


### PR DESCRIPTION
To comply with the pull request in the spiral/app repo. https://github.com/spiral/app/pull/11