### PR TITLE
Fix sample DB configuration in cookbook

### DIFF
--- a/basics/quick-start.md
+++ b/basics/quick-start.md
@@ -107,7 +107,9 @@ return [
     'drivers'   => [
         'runtime' => [
             'driver'     => Driver\SQLite\SQLiteDriver::class,
-            'connection' => 'sqlite:' . directory('runtime') . 'runtime.db',
+            'options'    => [
+                'connection' => 'sqlite:' . directory('runtime') . 'runtime.db',
+            ]
         ],
     ]
 ];
@@ -136,9 +138,11 @@ return [
     'drivers'   => [
         'default' => [
             'driver'     => Driver\MySQL\MySQLDriver::class,
-            'connection' => sprintf('mysql:host=%s;dbname=%s', env('DB_HOST'), env('DB_NAME')),
-            'username'   => env('DB_USER'),
-            'password'   => env('DB_PASSWORD'),
+            'options'    => [
+                'connection' => sprintf('mysql:host=%s;dbname=%s', env('DB_HOST'), env('DB_NAME')),
+                'username'   => env('DB_USER'),
+                'password'   => env('DB_PASSWORD'),
+            ]
         ],
     ]
 ];


### PR DESCRIPTION
Connection options for DB driver must be in "options" section.

Same issue in main documentation: https://github.com/spiral/docs/pull/141