### PR TITLE
docs: fix comment in demo codes

### DIFF
--- a/basics/quick-start.md
+++ b/basics/quick-start.md
@@ -607,7 +607,7 @@ class Comment
 
     /**
      * @Cycle\Relation\BelongsTo(target = "Post", nullable = false)
-     * @var User
+     * @var Post
      */
     public $post;
 }


### PR DESCRIPTION
The `Comment::post` property is `App\Database\Post`, not `App\Database\User`.