### PR TITLE
docs: fix wrong type in annotation comment

### DIFF
--- a/basics/quick-start.md
+++ b/basics/quick-start.md
@@ -1023,7 +1023,7 @@ class PostController
      */
     public function get(string $id)
     {
-        /** @var Post $post */
+        /** @var \App\Repository\PostRepository $post */
         $post = $this->posts->findByPK($id);
         if ($post === null) {
             throw new NotFoundException("post not found");


### PR DESCRIPTION
Here the `$this->posts` is an instance of `PostRepository`, not `Post`.