### PR TITLE
Fix typo of registering route group example

### DIFF
--- a/http/annotated-routes.md
+++ b/http/annotated-routes.md
@@ -59,7 +59,7 @@ class APIRoutes extends Bootloader
 {
     public function boot(GroupRegistry $groups)
     {
-        $groups->group('api')
+        $groups->getGroup('api')
                ->setPrefix('/api/v1')
                ->addMiddleware(SomeMiddelware::class);
     }


### PR DESCRIPTION
Fix typo of example route group code block, method `$groups->group()` are not exist, but exists `$groups->getGroup()` what did the same.