### PR TITLE
fix annotated routing demo

### DIFF
--- a/basics/quick-start.md
+++ b/basics/quick-start.md
@@ -277,7 +277,7 @@ use Spiral\Router\Annotation\Route;
 class HomeController
 {
     /**
-     * @Route(action="/", name="index", verbs={"GET"})
+     * @Route(route="/", name="index", methods={"GET"})
      */
     public function index()
     {


### PR DESCRIPTION
Available properties for `@Route` annotation are only `route`, `name`, `methods`, `defaults`, `group`, `middleware`, there are not `action` and `verbs`.