### PR TITLE
Fix error with Jobs in Docs

### DIFF
--- a/queue/scraper.md
+++ b/queue/scraper.md
@@ -88,7 +88,7 @@ depth reached. All the content will be stored in `runtime` directory.
 ```php
 namespace App\Job;
 
-use PHPHtmlParser\Dom;
+use \PHPHtmlParser\Dom;
 use Spiral\Jobs\JobHandler;
 use Spiral\Prototype\Traits\PrototypeTrait;
 


### PR DESCRIPTION
Added Preceding Back Slash Before the Native Namespace

Just to make the code run without errors

Here is the result without preceding backslash:

[Here is the Error](https://ibb.co/dtrgm8b)

[Here is the Success](https://ibb.co/N6QH8k8)

Closes #170

