### PR TITLE
Fix typo in Internationalization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@
     * [Components and Props](stempler/components.md)
     * [Advancing DSL](stempler/advanced.md)
     * [AST Modifications](stempler/visitors.md)
-* Internalization
+* Internationalization
     * [Installation and Configuration](i18n/configuration.md)
     * [Import and Export](i18n/export.md)
     * [View Localization](i18n/views.md)


### PR DESCRIPTION
Should be: https://en.wikipedia.org/wiki/Internationalization_and_localization
Not: https://en.wikipedia.org/wiki/Internalization