### PR TITLE
Fix typo in documentation

### DIFF
--- a/component/data-grid.md
+++ b/component/data-grid.md
@@ -495,7 +495,7 @@ This filter represents the SQL `between` operation, but can be presented as two 
 You have an ability to define whether the boundary values should be included or not.
 If the boundary values aren't included, this filter will be converted into `gt`+`lt` filters, otherwise when getting
 filters via `getFilters()` method you can specify either use the original `between` operator or `gte`+`lte` filters.
-> Not all databases support `between` operation, that's why converion to `gt/gte`+`lt/lte` is by default.
+> Not all databases support `between` operation, that's why conversion to `gt/gte`+`lt/lte` is by default.
 
 Between filter has two modifications: field-based and value-based:
 ```php

--- a/component/files.md
+++ b/component/files.md
@@ -5,7 +5,7 @@ The framework provides a simple component to work with the filesystem. The compo
 Most of the spiral components rely on the directory registry instead of hard-coded paths.
 The registry represented using `Spiral\Boot\DirectoriesInterface`.
 
-You can configure application specific directories in the app enterpoint (app.php):
+You can configure application specific directories in the app entry point (app.php):
 
 ```php
 $app = \App\App::init([

--- a/database/declaration.md
+++ b/database/declaration.md
@@ -292,7 +292,7 @@ $schema->string('email')->setName('new_email');
 $schema->renameColumn('email', 'new_email');
 ```
 
-> Call the `save` method of `AbstactTable` to save your changes.
+> Call the `save` method of `AbstractTable` to save your changes.
 
 Use a similar approach to rename indexes and table names.
 

--- a/database/query-builders.md
+++ b/database/query-builders.md
@@ -395,7 +395,7 @@ $select = $db->select()
 
 $select->where('id', $id = new Parameter(null));
 
-//Bing new parameter value
+//Bind new parameter value
 $id->setValue(15);
 
 foreach ($select as $row) {
@@ -719,7 +719,7 @@ INNER JOIN `primary_users` as `uu`
 User `orderBy` to specify sort direction:
 
 ```php
-//We have a join, so table name is mandratory
+//We have a join, so table name is mandatory
 $select
     ->orderBy('test.id', SelectQuery::SORT_DESC);
 ```

--- a/framework/container.md
+++ b/framework/container.md
@@ -10,7 +10,7 @@ You can always access the container directly in your code by requesting `Psr\Con
 ```php
 use Psr\Container\ContainerInterface;
 
-class HomeContoller
+class HomeController
 {
     public function index(ContainerInterface $container)
     {
@@ -224,10 +224,10 @@ __construct(OtherClass $class, $value)
 // will use `null` as `value` if no other value provided
 __construct(OtherClass $class, $value = null) 
 
-// will fail if SomeInterface does not point to the concrete implemenation
+// will fail if SomeInterface does not point to the concrete implementation
 __construct(OtherClass $class, SomeInterface $some) 
 
-// will use null as value of `some` if no conrete implemation is provided
+// will use null as value of `some` if no concrete implementation is provided
 __construct(OtherClass $class, SomeInterface $some = null) 
 ```
 

--- a/framework/scopes.md
+++ b/framework/scopes.md
@@ -1,5 +1,5 @@
 # Framework - IoC Scopes
-An essential aspect of developing long-living applications is proper context management. In daemonized applications,
+An essential aspect of developing long-living applications is proper context management. In demonized applications,
 you are no longer allowed to treat user requests as global singleton object and store references to its instance in your services.
 
 Practically it means that you must explicitly request context while processing user input. Spiral framework simplifies

--- a/http/annotated-routes.md
+++ b/http/annotated-routes.md
@@ -61,7 +61,7 @@ class APIRoutes extends Bootloader
     {
         $groups->getGroup('api')
                ->setPrefix('/api/v1')
-               ->addMiddleware(SomeMiddelware::class);
+               ->addMiddleware(SomeMiddleware::class);
     }
 }
 ```

--- a/http/cookies.md
+++ b/http/cookies.md
@@ -156,7 +156,7 @@ return [
     // protection method
     'method'   => CookiesConfig::COOKIE_ENCRYPT,
 
-    // whitelisted cookies (no ecnrypt/descrypt)
+    // whitelisted cookies (no encrypt/decrypt)
     'excluded' => ['PHPSESSID', 'csrf-token']
 ];
 ```

--- a/http/middleware.md
+++ b/http/middleware.md
@@ -120,7 +120,7 @@ public function index(UserContext $ctx)
 ```
 
 ## Non-Direct Scope Configuration
-You can use already exists requets scope to carry user values. Create bootloader providing access method for the context specific value:
+You can use already exists requests scope to carry user values. Create bootloader providing access method for the context specific value:
 
 ```php
 use Psr\Http\Message\ResponseInterface;

--- a/http/routing.md
+++ b/http/routing.md
@@ -564,7 +564,7 @@ $router->setRoute('app',
 > `/demo` will trigger not-found error as `DemoController` does not defines method `index`.
 
 The default web-application bundle sets this route [as default](https://github.com/spiral/app/blob/master/app/src/Bootloader/RoutesBootloader.php#L42).
-You don't need to create a route for any of the controllers added to `App\Contoller`, simply use `/controller/action` URLs
+You don't need to create a route for any of the controllers added to `App\Controller`, simply use `/controller/action` URLs
 to access the required method. If no action is specified, the `index` will be used by the default. The routing will point
 to the public methods only.
 

--- a/queue/jobs.md
+++ b/queue/jobs.md
@@ -6,7 +6,7 @@ come with pre-configured `jobs` service capable of running your tasks using an `
 
 ## Create Handler
 To run a job, you must create a proper job handler. The handler must implement `Spiral\Jobs\HandlerInterface`. Handlers are
-responsible for job payload serialization and execution. Use `Spiral\Jobs\JobHanlder` to simplify your abstraction
+responsible for job payload serialization and execution. Use `Spiral\Jobs\JobHandler` to simplify your abstraction
 and perform dependency injection in your handler method `invoke`:
 
 ```php


### PR DESCRIPTION
Fixed the spelling mistake `conversion` in component/data-grid.md file, line 498, and Instead, of `enterpoint` in component/files.md, I think it should be `entry point` which makes more sense.

Fixed the spelling mistake `AbstractTable` in database/declaration.md file, line 295. And the other two spelling mistakes in database/query-builders.

Fixed a few spelling mistakes in the framework's container and scopes documentation files, also in HTTP documentation files: annotated-routes, cookies, middleware, and routing. With a final fix on the queue jobs documentation file.